### PR TITLE
Fixed a bug on ->update and ->delete 

### DIFF
--- a/PPI/DataSource/ActiveQuery.php
+++ b/PPI/DataSource/ActiveQuery.php
@@ -73,11 +73,11 @@ class ActiveQuery {
 	}
 
 	function delete($where) {
-		return $this->_handler->delete($this->_meta['table'], $where);
+		return $this->_handler->delete($where);
 	}
 	
 	function update($data, $where) {
-		return $this->_handler->update($this->_meta['table'], $data, $where);
+		return $this->_handler->update($data, $where);
 	}
 
 }


### PR DESCRIPTION
This is what happened:

PPI\DataSource\ActiveQuery.php:

function delete($where) {
    return $this->_handler->delete($this->_meta['table'], $where);
}

function update($data, $where) {
    return $this->_handler->update($this->_meta['table'], $data, $where);
}

// The Handler in this class is PP\DataSource\PDO\ActiveQuery.php:

function delete($where) {
    return $this->_conn->delete($this->_meta['table'], $where);
}

function update($data, $where) {
    return $this->_conn->update($this->_meta['table'], $data, $where);
}

So, what's the problem? -- Easy, the functions on the ActiveQuery class are sending the it'stable as the first parameter, however, the 'handler' class in this case \PDO\ActiveQuery is not taking the table as a parameter, so, it was taking the table param (sent by the child class) as if it was the actual data.

regards,
Alfredo
