### PR TITLE
Fixed case inconsistency in unit tests for PPI\Form\Rule\Maxlength

### DIFF
--- a/PPI/Test/Form/MaxlengthRuleTest.php
+++ b/PPI/Test/Form/MaxlengthRuleTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace PPI\Test\Form;
-use PPI\Form\Rule\MaxLength;
-class MaxLengthRuleTest extends \PHPUnit_Framework_TestCase {
+use PPI\Form\Rule\Maxlength;
+class MaxlengthRuleTest extends \PHPUnit_Framework_TestCase {
 
 	function setUp() {
 		$this->_rule = new Maxlength();


### PR DESCRIPTION
The issue fixed by this patch prevents tests for PPI\Form\Rule\Maxlength from running on case-sensitive filesystems.
