### PR TITLE
Bug/monolog config broken

### DIFF
--- a/src/ServiceManager/Config/MonologConfig.php
+++ b/src/ServiceManager/Config/MonologConfig.php
@@ -132,14 +132,14 @@ class MonologConfig extends AbstractConfig
     /**
      * {@inheritDoc}
      */
-    protected function processConfiguration(array $config, ServiceManager $serviceManager = null)
+    protected function processConfiguration(array $configs, ServiceManager $serviceManager = null)
     {
         $alias = $this->getAlias();
         if (!isset($configs[$alias])) {
             return array();
         }
 
-        $parameterBag = $serviceManager->get('config.parameter_bag');
+        $parameterBag = $serviceManager->get('application_parameters');
         $config = $configs[$alias];
 
         if (isset($config['handlers'])) {


### PR DESCRIPTION
There was a problem in the Monolog service configuration which was causing it to bail out before it had the chance to be registered.

The original problem was an inconsistency in variable and service naming (changed `$config` -> `$configs` and `config.parameter_bag` -> `application-parameters`. See: https://github.com/garyttierney/framework/commit/4194f9faa47ff36b9bbbc1c218ab8f3d73ddf98c

This gets Monolog working on 2.1., but the 'Logger' alias had been removed from ServiceManager, which was causing a lot of stuff to bail out, presumably unless the Monolog Module was enabled. See: https://github.com/garyttierney/framework/commit/586135851ebd9f45546f8d6843dcb1b0ed345310#diff-b5872d4ed42748960eccd9f052d4c9acR94
