### PR TITLE
Bug/non existent logger service

### DIFF
--- a/src/Log/LoggerProxy.php
+++ b/src/Log/LoggerProxy.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace PPI\Log;
+
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
+
+class LoggerProxy
+{
+
+    /**
+     * @var Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Sets the instance of LoggerInterface used by this proxy.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(PsrLoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * An implementation of the magic method {@code __call} which proxies any method calls through to the underlying {@link LoggerInterface}.
+     */
+    public function __call($method, $args)
+    {
+        if (!is_null($this->logger)) {
+            if (!method_exists($this->logger, $method)) {
+                throw new \Exception(sprintf("Error: called unknown method '%s' with args %s", $method, print_r($args, true)));
+            }
+
+            return call_user_func_array(array($this->logger, $method), $args);
+        }
+
+        //@todo - should we really return from here?
+        return null;
+    }
+}

--- a/src/Log/LoggerProxy.php
+++ b/src/Log/LoggerProxy.php
@@ -16,7 +16,7 @@ class LoggerProxy implements LoggerInterface
 {
 
     /**
-     * @var Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     private $logger;
 

--- a/src/Log/LoggerProxy.php
+++ b/src/Log/LoggerProxy.php
@@ -5,7 +5,14 @@ namespace PPI\Log;
 
 use Psr\Log\LoggerInterface as PsrLoggerInterface;
 
-class LoggerProxy
+/**
+ * This is a class which wraps around Psr\Log to provide a proxy to an underlying Logger implementation. This enables us
+ * to boot up the PPI framework without actually setting a logger in the ServiceManager.
+ *
+ * @package PPI
+ * @author Gary Tierney
+ */
+class LoggerProxy implements LoggerInterface
 {
 
     /**
@@ -38,5 +45,77 @@ class LoggerProxy
 
         //@todo - should we really return from here?
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function emergency($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alert($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function critical($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warning($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notice($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function debug($message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = array())
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
     }
 }

--- a/src/ServiceManager/Config/LoggerProxyConfig.php
+++ b/src/ServiceManager/Config/LoggerProxyConfig.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace PPI\ServiceManager\Config;
+
+
+class LoggerProxyConfig extends AbstractConfig{
+
+} 

--- a/src/ServiceManager/ServiceManagerBuilder.php
+++ b/src/ServiceManager/ServiceManagerBuilder.php
@@ -8,6 +8,7 @@
  */
 
 namespace PPI\ServiceManager;
+use PPI\Log\LoggerProxy;
 
 /**
  * ServiceManager builder.
@@ -48,6 +49,13 @@ class ServiceManagerBuilder extends ServiceManager
 
         // Settings provided by the application itself on App boot, config provided by modules is not included
         $this->setService('ApplicationConfig', $parametersBag->resolveArray($this->config));
+
+        $loggerProxy = new LoggerProxy();
+        if($this->has('Logger')) {
+            $loggerProxy->setLogger($this->get('Logger'));
+        }
+
+        $this->setService('Logger', $loggerProxy);
 
         foreach(array(
             new Config\SessionConfig(),


### PR DESCRIPTION
Given that the framework shouldn't be responsible for creating and managing a Logger for the entire application, we needed a way to prevent any code which depended on the 'Logger' service being available from throwing fatal errors.

This PR addresses this problem by creating a proxy class which overrides the __call() magic method to automatically forward log invocations through to the underlying implementation. The LoggerProxy class itself also inherits from Psr\Log\LoggerInterface, which prevents type-hinting and instanceof checks from breaking.