### PR TITLE
Updating zf to 2.1.6 because of a ZF bug in 2.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
         "symfony/routing": "2.1.*@stable",
         "symfony/console": "2.1.*@stable",
         "twig/twig": ">=1.8,<2.0-dev",
-        "zendframework/zend-stdlib": "2.1.3",
-        "zendframework/zend-loader": "2.1.3",
-        "zendframework/zend-servicemanager": "2.1.3",
-        "zendframework/zend-eventmanager": "2.1.3",
-        "zendframework/zend-modulemanager": "2.1.3"
+        "zendframework/zend-stdlib": "2.1.6",
+        "zendframework/zend-loader": "2.1.6",
+        "zendframework/zend-servicemanager": "2.1.6",
+        "zendframework/zend-eventmanager": "2.1.6",
+        "zendframework/zend-modulemanager": "2.1.6"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
There's a bug in ZF stdlib 2.1.3, which was fixed in 2.1.6

`Warning: require(/var/www/html/vendor/zendframework/zend-stdlib/Zend/Stdlib/compatibility/autoload.php): failed to open stream: No such file or directory in /var/www/html/vendor/composer/autoload_real.php on line 55`

`Fatal error: require(): Failed opening required '/var/www/html/vendor/zendframework/zend-stdlib/Zend/Stdlib/compatibility/autoload.php' (include_path='.:/usr/share/pear:/usr/share/php') in /var/www/html/vendor/composer/autoload_real.php on line 55`

Upgrading to zf 2.1.6 resolves this problem. 